### PR TITLE
[FAT32] [THREAD] [TSS\IDT] [BOOTLOADER] [MEMORY] [MISC] Fixed some FAT32 driver vulnerabilities, fixed stack being too small for threads...

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ MatanelOS is a 64-bit operating system built from scratch, inspired by Windows k
 | Feature | Status |
 |---------|--------|
 | Virtual File System (VFS) | ![✔️](https://img.shields.io/badge/status-WORKING-green) |
-| FAT32 Driver | ![✔️](https://img.shields.io/badge/status-WORKING-green) |
+| FAT32 Driver | ![✔️](https://img.shields.io/badge/status-PARTIALLY_BROKEN-darkred) |
 
 ---
 
@@ -83,6 +83,7 @@ MatanelOS is a 64-bit operating system built from scratch, inspired by Windows k
 MatanelOS is a preemptive, 64-bit kernel with Windows-inspired architecture. It’s designed for learning, low-level OS experimentation, and controlled testing in virtual environments.
 
 *Use this project responsibly. Intended for educational purposes only.*
+
 
 
 


### PR DESCRIPTION
The thread's stack was too small to allocate all of the function calls, local variables and more in fat32_write_file, resulting in the stack being smashed down and overrun (which resulted also in its block metadata being overrun), this is why I added guard pages (which didn't work at the time, so I didn't know what was the root of the problem, after 1 week of debugging)

Increased stack size for threads from 4KiB to 16 KiB.